### PR TITLE
Add loginpage props on admin component usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ export const authProvider = supabaseAuthProvider(supabase, {
 
 // in App.js
 import { Admin, Resource, ListGuesser } from 'react-admin';
-import { authRoutes } from 'ra-supabase';
+import { authRoutes, LoginPage } from 'ra-supabase';
 import { dataProvider } from './dataProvider';
 import { authProvider } from './authProvider';
 
@@ -72,6 +72,7 @@ export const MyAdmin = () => (
         dataProvider={dataProvider}
         authProvider={authProvider}
         customRoutes={authRoutes}
+        loginPage={LoginPage}
     >
         <Resource name="posts" list={ListGuesser} />
         <Resource name="authors" list={ListGuesser} />


### PR DESCRIPTION
### Background
When I was trying to use this library, I approach an issue that I couldn't login using supabase auth. Error message `You must provide either an email, phone number or a third-party provider.` pops on the bottom of the page. I checked on the `demo` directory that it actually needs to pass LoginPage component to loginPage props of Admin component.

The readme might confuse another user as well, so I suggest this edit.

Issue:

<img width="580" alt="Screen Shot 2021-12-17 at 22 06 30" src="https://user-images.githubusercontent.com/18479742/146566496-3be69052-5892-400a-a004-7a9cea84a094.png">
