### PR TITLE
Add missing classnames dependency

### DIFF
--- a/packages/ra-supabase-ui-materialui/package.json
+++ b/packages/ra-supabase-ui-materialui/package.json
@@ -15,6 +15,7 @@
     "types": "esm/index.d.ts",
     "sideEffects": false,
     "dependencies": {
+        "classnames": "^2.3.2",
         "ra-supabase-core": "^1.2.1"
     },
     "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3825,6 +3825,11 @@ classnames@*:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
+classnames@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
 classnames@~2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"


### PR DESCRIPTION
It seems you have a missing dependency here! Causes this in a new React Admin project:

![image](https://user-images.githubusercontent.com/5636273/211212740-c5cd2717-deb2-4907-9f48-a5ea80e58e07.png)

Used here:

https://github.com/marmelab/ra-supabase/blob/479654d3f9b205b1afbb6d386b442db940256e16/packages/ra-supabase-ui-materialui/src/AuthLayout.tsx#L81

