### PR TITLE
support redirectTo in SupabaseAuthProviderOptions

### DIFF
--- a/packages/ra-supabase-core/src/authProvider.ts
+++ b/packages/ra-supabase-core/src/authProvider.ts
@@ -3,7 +3,7 @@ import { Provider, SupabaseClient, User } from '@supabase/supabase-js';
 
 export const supabaseAuthProvider = (
     client: SupabaseClient,
-    { getIdentity }: SupabaseAuthProviderOptions
+    { getIdentity, redirectTo }: SupabaseAuthProviderOptions
 ): SupabaseAuthProvider => {
     return {
         async login(params) {
@@ -22,7 +22,7 @@ export const supabaseAuthProvider = (
 
             const oauthParams = params as LoginWithOAuthParams;
             if (oauthParams.provider) {
-                client.auth.signInWithOAuth(oauthParams);
+                client.auth.signInWithOAuth({ oauthParams, options: { redirectTo });
                 // To avoid react-admin to consider this as an immediate success,
                 // we return a rejected promise that is handled by the default OAuth login buttons
                 return Promise.reject();
@@ -84,7 +84,7 @@ export const supabaseAuthProvider = (
             if (type === 'recovery' || type === 'invite') {
                 if (access_token && refresh_token) {
                     return {
-                        redirectTo: `set-password?access_token=${access_token}&refresh_token=${refresh_token}&type=${type}`,
+                        redirectTo: `${redirectTo}/set-password?access_token=${access_token}&refresh_token=${refresh_token}&type=${type}`,
                     };
                 }
 
@@ -112,7 +112,7 @@ export const supabaseAuthProvider = (
                 if (access_token && refresh_token) {
                     // eslint-disable-next-line no-throw-literal
                     throw {
-                        redirectTo: `set-password?access_token=${access_token}&refresh_token=${refresh_token}&type=${type}`,
+                        redirectTo: `${redirectTo}/set-password?access_token=${access_token}&refresh_token=${refresh_token}&type=${type}`,
                         message: false,
                     };
                 }
@@ -154,6 +154,7 @@ export const supabaseAuthProvider = (
 export type GetIdentity = (user: User) => Promise<UserIdentity>;
 export type SupabaseAuthProviderOptions = {
     getIdentity?: GetIdentity;
+    redirectTo?: string;
 };
 
 type LoginWithEmailPasswordParams = {
@@ -163,6 +164,7 @@ type LoginWithEmailPasswordParams = {
 
 type LoginWithOAuthParams = {
     provider: Provider;
+    redirectTo?: string; 
 };
 
 type LoginWithMagicLink = {


### PR DESCRIPTION
Thanks in advance for all your work, first of all. I am submitting these changes in order to achieve a specific behavior regarding redirect URLs that I think should be supported by this package.

# Summary

Support the use of `redirectTo` option in `supabase` client to use custom redirect URLs after signing in with OAuth providers. The same `redirectTo` property in `supabaseAuthProvider` arguments works for Set and Reset password flows.

# Problem

This is the case I was dealing with:
- Using an OAuth provider (such as Google).
- The need to implement different authentication flows across the application (one for customers and another for administrators).
- Placing `react-admin` root component (`<Admin authProvider={...}>...</Admin>`) in a custom route (such as `/admin`) different from `/`.

If all of these conditions are true, the `react-admin` authentication provider will fail to complete the authentication flow, since the access and refresh tokens never get to the `Admin` component as expected. Since the `supabase` client uses the `SITE_URL` by default, and the customer authentication flow needs it to be set to the root URL of the web application, it is impossible to use an alternative authentication flow using `ra-supabase`, as it will try to redirect to the root URL instead of the custom admin URL.

# Solution

Allowing the developer to set an additional string property `redirectTo` in `SupabaseAuthProviderOptions` and using its value as a parameter when calling `signInWithOAuth`, [as it is described in the Supabase documentation](https://supabase.com/docs/reference/javascript/auth-signinwithoauth).

Additionally, the same value can be used to achieve this behavior in the `set-password` flow.

# Notes

Feel free to leave a comment if you feel I can fix anything, especially with the `set-password` case. Since I am only using the OAuth flow, I don't actually need to set or reset passwords, so I haven't been able to test those flows too much.