### PR TITLE
fix: corrected raSupabaseFrenchMessages

### DIFF
--- a/packages/ra-supabase-language-french/src/index.ts
+++ b/packages/ra-supabase-language-french/src/index.ts
@@ -1,4 +1,4 @@
-export const raSupabaseEnglishMessages = {
+export const raSupabaseFrenchMessages = {
     'ra-supabase': {
         auth: {
             email: 'Email',


### PR DESCRIPTION
In order to be consisten with the rest of the documentation, the french localization needs to be exported as raSupabaseFrenchMessages and not as raSupabaseEnglishMessages