### PR TITLE
Fixes set password flow doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ make run
 
 The current version of supabase CLI does not allow to customize the emails sent for invitation or password reset.
 
-When you invite a new user through the [Authentication dashboard](http://localhost:54323/project/default/auth/users), you can see the email sent in [Inbucket](http://localhost:54324/monitor). Instead of clicking the link, copy it and change the `redirect_to` parameter from `http://localhost:8000` to `http://localhost:8000/handle-callback`.
+When you invite a new user through the [Authentication dashboard](http://localhost:54323/project/default/auth/users), you can see the email sent in [Inbucket](http://localhost:54324/monitor). Instead of clicking the link, copy it and change the `redirect_to` parameter from `http://localhost:8000` to `http://localhost:8000/auth-callback`.
 
 Apply the same process for password reset emails.
 

--- a/packages/ra-supabase-core/src/authProvider.ts
+++ b/packages/ra-supabase-core/src/authProvider.ts
@@ -88,7 +88,7 @@ export const supabaseAuthProvider = (
                 if (access_token && refresh_token) {
                     return {
                         redirectTo: `${
-                            redirectTo ? `${redirectTo}/` : ''
+                            redirectTo ? `${redirectTo}/` : '/'
                         }set-password?access_token=${access_token}&refresh_token=${refresh_token}&type=${type}`,
                     };
                 }
@@ -118,7 +118,7 @@ export const supabaseAuthProvider = (
                     // eslint-disable-next-line no-throw-literal
                     throw {
                         redirectTo: `${
-                            redirectTo ? `${redirectTo}/` : ''
+                            redirectTo ? `${redirectTo}/` : '/'
                         }set-password?access_token=${access_token}&refresh_token=${refresh_token}&type=${type}`,
                         message: false,
                     };

--- a/packages/ra-supabase/README.md
+++ b/packages/ra-supabase/README.md
@@ -151,8 +151,8 @@ This requires you to configure your supabase instance:
 
 1. Go to your dashboard **Authentication** section
 1. In **URL Configuration**, set **Site URL** to your application URL
-1. In **URL Configuration**, add the following URL in the **Redirect URLs** section: `YOUR_APPLICATION_URL/handle-callback`
-1. In **Email Templates**, change the `"{{ .ConfirmationURL }}"` to `"{{ .ConfirmationURL }}/handle-callback"` 
+1. In **URL Configuration**, add the following URL in the **Redirect URLs** section: `YOUR_APPLICATION_URL/auth-callback`
+1. In **Email Templates**, change the `"{{ .ConfirmationURL }}"` to `"{{ .ConfirmationURL }}/auth-callback"` 
 
 You can now add the `/set-password` custom route:
 
@@ -192,8 +192,8 @@ This requires you to configure your supabase instance:
 
 1. Go to your dashboard **Authentication** section
 1. In **URL Configuration**, set **Site URL** to your application URL
-1. In **URL Configuration**, add the following URL in the **Redirect URLs** section: `YOUR_APPLICATION_URL/handle-callback`
-1. In **Email Templates**, change the `"{{ .ConfirmationURL }}"` to `"{{ .ConfirmationURL }}/handle-callback"` 
+1. In **URL Configuration**, add the following URL in the **Redirect URLs** section: `YOUR_APPLICATION_URL/auth-callback`
+1. In **Email Templates**, change the `"{{ .ConfirmationURL }}"` to `"{{ .ConfirmationURL }}/auth-callback"` 
 
 You can now add the `/forgot-password` and `/set-password` custom routes:
 
@@ -261,7 +261,7 @@ This also requires you to configure the redirect URLS on your supabase instance:
 
 1. Go to your dashboard **Authentication** section
 1. In **URL Configuration**, set **Site URL** to your application URL
-1. In **URL Configuration**, add the following URL in the **Redirect URLs** section: `YOUR_APPLICATION_URL/handle-callback`
+1. In **URL Configuration**, add the following URL in the **Redirect URLs** section: `YOUR_APPLICATION_URL/auth-callback`
 
 To disable email/password authentication, set the `disableEmailPassword` prop:
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -42,7 +42,7 @@ file_size_limit = "50MiB"
 # in emails.
 site_url = "http://localhost:8000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["http://localhost:8000/handle-callback"]
+additional_redirect_urls = ["http://localhost:8000/auth-callback"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 seconds (one
 # week).
 jwt_expiry = 3600


### PR DESCRIPTION
- update handle-callback path to auth-callback. since react admin 4.x callback path got updated.
- update redirect path to `/set-password` in the authprovider.