### PR TITLE
Update supabase-js dev to match new auth system

### DIFF
--- a/packages/ra-supabase-core/package.json
+++ b/packages/ra-supabase-core/package.json
@@ -20,8 +20,8 @@
         "ra-core": "^4.7.0"
     },
     "devDependencies": {
-        "@raphiniert/ra-data-postgrest": "^2.0.0",
-        "@supabase/supabase-js": "^2.4.1",
+        "@raphiniert/ra-data-postgrest": "^2.1.0",
+        "@supabase/supabase-js": "^2.43.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",


### PR DESCRIPTION
Hello RA team,

Supabase update their authSystem last week resulting in throwing a 403 error instead of a 401+logout as before.
It makes that when we connect, sometimes we get stuck in a limbo between trying to connect and accessing React-Admin.

I addressed that issue to Supabase team and this is their answer:

**This error is returned when we detect that the session_id claim in the access token doesn't exist in the auth.sessions table. It was introduced in this PR (https://github.com/supabase/auth/pull/1538) because we realised that we were returning the wrong error when the session is missing. Before this PR was merged, the sign out API would return a panic and fail silently, returning a 5xx error to the client which can't be handled.

You can fix this by doing either one of these options:

    Manually ignore 403s returned from signOut and just clear the local session stored on the browser.
    Upgrade to supabase-js v2.43.1 which contains the changes to ignore 403s returned by the signOut method**
 
This push updates the devDependencies version of both supabase-js and @raphiniert/ra-data-postgrest

Kind regards,