### PR TITLE
Fix(authProvider): It is no longer possible to access a page using direct URL if user is logged out

### DIFF
--- a/packages/ra-supabase-core/src/authProvider.ts
+++ b/packages/ra-supabase-core/src/authProvider.ts
@@ -1,5 +1,5 @@
-import { AuthProvider, UserIdentity } from 'ra-core';
 import { Provider, SupabaseClient, User } from '@supabase/supabase-js';
+import { AuthProvider, UserIdentity } from 'ra-core';
 
 export const supabaseAuthProvider = (
     client: SupabaseClient,
@@ -74,7 +74,13 @@ export const supabaseAuthProvider = (
             }
         },
         async checkError(error) {
-            if (error.status === 401 || error.status === 403) {
+            if (
+                error.status === 401 ||
+                error.status === 403 ||
+                // Supabase returns 400 when the session is missing, we need to check this case too.
+                (error.status === 400 &&
+                    error.name === 'AuthSessionMissingError')
+            ) {
                 return Promise.reject();
             }
 


### PR DESCRIPTION
## Problem

It was possible to access restricted pages via URL if user was logged out

## Solution

Handle `AuthSessionMissingError` from supabase in `supabaseAuthProvider.checkError`

## How To Test

1. Run the local demo
2. Make sure you are not logged in (sign out if necessary)
3. Browse to http://localhost:8001/contacts

BEFORE: user would see the CRM layout, with an empty ContactList page (and not be redirected to the login page)
AFTER: user is automatically redirected to the login page