### PR TITLE
Align style in readme for language packages

### DIFF
--- a/packages/ra-supabase-language-english/README.md
+++ b/packages/ra-supabase-language-english/README.md
@@ -5,9 +5,9 @@ English translations for [ra-supabase](https://www.npmjs.com/package/ra-supabase
 ## Installation
 
 ```sh
-npm install ra-supabase-language-english
-# or
 yarn add ra-supabase-language-english
+# or
+npm install ra-supabase-language-english
 ```
 
 ## Usage

--- a/packages/ra-supabase-language-french/README.md
+++ b/packages/ra-supabase-language-french/README.md
@@ -5,9 +5,9 @@ French translations for [ra-supabase](https://www.npmjs.com/package/ra-supabase)
 ## Installation
 
 ```sh
-npm install ra-supabase-language-french
-# or
 yarn add ra-supabase-language-french
+# or
+npm install ra-supabase-language-french
 ```
 
 ## Usage


### PR DESCRIPTION
When you follow guideline in https://github.com/marmelab/ra-supabase you go to the following pages:
- https://github.com/marmelab/ra-supabase/tree/main/packages/ra-supabase
- https://github.com/marmelab/ra-supabase/tree/main/packages/ra-supabase-core
- https://github.com/marmelab/ra-supabase/tree/main/packages/ra-supabase-ui-materialui
- and language packages,

all follow the style when yarn is first, then npm. 
In language packages it is the other way round, npm and then yarn.
- https://github.com/marmelab/ra-supabase/tree/main/packages/ra-supabase-language-english
- https://github.com/marmelab/ra-supabase/tree/main/packages/ra-supabase-language-french

So when you copy-paste commands it is easy to make a mistake. Let's align all the readmes to one style.