### PR TITLE
Fix code in dataProvider example in readme

### DIFF
--- a/packages/ra-supabase-core/README.md
+++ b/packages/ra-supabase-core/README.md
@@ -20,12 +20,12 @@ export const supabase = createClient('YOUR_SUPABASE_URL', 'YOUR_SUPABASE_ANON_KE
 
 // in dataProvider.js
 import { supabaseDataProvider } from 'ra-supabase-core';
-import { supabaseClient } from './supabase';
+import { supabase } from './supabase';
 
 export const dataProvider = supabaseDataProvider({
     instanceUrl: 'YOUR_SUPABASE_URL',
     apiKey: 'YOUR_SUPABASE_ANON_KEY',
-    supabaseClient
+    supabase
 });
 
 // in authProvider.js


### PR DESCRIPTION
In example code, we export `supabase` instead of `supabaseClient` in supabase.js file, so import causes error in dataProvider.

```js
// in supabase.js
import { createClient } from '@supabase/supabase-js';
export const supabase = createClient('YOUR_SUPABASE_URL', 'YOUR_SUPABASE_ANON_KEY');
```