### PR TITLE
Add ability to pass additional options to postgrest

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,19 @@ You can then start the application in `development` mode with:
 make run
 ```
 
-### Testing Invitations And Password Reset
+Log in with the following credentials:
 
+- Email: `janedoe@atomic.dev`
+- Password: `password`
+
+If you need debug the backend, you can access the following services: 
+
+- Supabase dashboard: [http://localhost:54323/](http://localhost:54323/)
+- REST API: [http://127.0.0.1:54321](http://127.0.0.1:54321)
+- Attachments storage: [http://localhost:54323/project/default/storage/buckets/attachments](http://localhost:54323/project/default/storage/buckets/attachments)
+- Inbucket email testing service: [http://localhost:54324/](http://localhost:54324/)
+
+### Testing Invitations And Password Reset
 
 The current version of supabase CLI does not allow to customize the emails sent for invitation or password reset.
 

--- a/packages/ra-supabase-core/src/dataProvider.ts
+++ b/packages/ra-supabase-core/src/dataProvider.ts
@@ -24,18 +24,14 @@ export const supabaseDataProvider = ({
     apiKey,
     supabaseClient = createClient(instanceUrl, apiKey),
     httpClient = supabaseHttpClient({ apiKey, supabaseClient }),
-    postgrestConfig,
-    /* @deprecated Use postgrestConfig instead */
     defaultListOp = 'eq',
-    /* @deprecated Use postgrestConfig instead */
     primaryKeys = defaultPrimaryKeys,
-    /* @deprecated Use postgrestConfig instead */
     schema = defaultSchema,
+    ...rest
 }: {
     instanceUrl: string;
     apiKey: string;
     supabaseClient?: SupabaseClient;
-    postgrestConfig?: Partial<Omit<IDataProviderConfig, 'apiUrl'>>;
 } & Partial<Omit<IDataProviderConfig, 'apiUrl'>>): DataProvider => {
     const config: IDataProviderConfig = {
         apiUrl: `${instanceUrl}/rest/v1`,
@@ -43,7 +39,7 @@ export const supabaseDataProvider = ({
         defaultListOp,
         primaryKeys,
         schema,
-        ...postgrestConfig,
+        ...rest,
     };
     return postgrestRestProvider(config);
 };

--- a/packages/ra-supabase-core/src/dataProvider.ts
+++ b/packages/ra-supabase-core/src/dataProvider.ts
@@ -16,7 +16,6 @@ import type { SupabaseClient } from '@supabase/supabase-js';
  * @param defaultListOp Optional - The default list filter operator. Defaults to 'eq'.
  * @param primaryKeys Optional - The primary keys of the tables. Defaults to 'id'.
  * @param schema Optional - The custom schema to use. Defaults to none.
- * @param postgrestConfig Optional - The postgrest configuration. Defaults to none.
  * @returns A dataProvider for Supabase
  */
 export const supabaseDataProvider = ({

--- a/packages/ra-supabase-core/src/dataProvider.ts
+++ b/packages/ra-supabase-core/src/dataProvider.ts
@@ -4,30 +4,38 @@ import postgrestRestProvider, {
     defaultPrimaryKeys,
     defaultSchema,
 } from '@raphiniert/ra-data-postgrest';
-import { SupabaseClient } from '@supabase/supabase-js';
+import { createClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
 /**
  * A function that returns a dataProvider for Supabase.
  * @param instanceUrl The URL of the Supabase instance
  * @param apiKey The API key of the Supabase instance. Prefer the anonymous key.
  * @param supabaseClient The Supabase client
+ * @param httpClient Optional - The httpClient to use. Defaults to a httpClient that handles the authentication.
  * @param defaultListOp Optional - The default list filter operator. Defaults to 'eq'.
  * @param primaryKeys Optional - The primary keys of the tables. Defaults to 'id'.
  * @param schema Optional - The custom schema to use. Defaults to none.
+ * @param postgrestConfig Optional - The postgrest configuration. Defaults to none.
  * @returns A dataProvider for Supabase
  */
 export const supabaseDataProvider = ({
     instanceUrl,
     apiKey,
-    supabaseClient,
+    supabaseClient = createClient(instanceUrl, apiKey),
     httpClient = supabaseHttpClient({ apiKey, supabaseClient }),
+    postgrestConfig,
+    /* @deprecated Use postgrestConfig instead */
     defaultListOp = 'eq',
+    /* @deprecated Use postgrestConfig instead */
     primaryKeys = defaultPrimaryKeys,
+    /* @deprecated Use postgrestConfig instead */
     schema = defaultSchema,
 }: {
     instanceUrl: string;
     apiKey: string;
-    supabaseClient: SupabaseClient;
+    supabaseClient?: SupabaseClient;
+    postgrestConfig?: Partial<Omit<IDataProviderConfig, 'apiUrl'>>;
 } & Partial<Omit<IDataProviderConfig, 'apiUrl'>>): DataProvider => {
     const config: IDataProviderConfig = {
         apiUrl: `${instanceUrl}/rest/v1`,
@@ -35,6 +43,7 @@ export const supabaseDataProvider = ({
         defaultListOp,
         primaryKeys,
         schema,
+        ...postgrestConfig,
     };
     return postgrestRestProvider(config);
 };

--- a/packages/ra-supabase/README.md
+++ b/packages/ra-supabase/README.md
@@ -155,7 +155,7 @@ As users authenticate through supabase, you can leverage [Row Level Security](ht
 
 #### Customizing the dataProvider
 
-`supabaseDataProvider` also accepts the same options as the `ra-data-postgrest` dataProvider (except `apiUrl`), like [`primaryKeys`](https://github.com/raphiniert-com/ra-data-postgrest/blob/master/README.md#compound-primary-keys) or [`schema`](https://github.com/raphiniert-com/ra-data-postgrest/blob/master/README.md#custom-schema).
+`supabaseDataProvider` also accepts a `postgrestOptions` object to initialize the `ra-data-postgrest` dataProvider. This object accepts options like [`primaryKeys`](https://github.com/raphiniert-com/ra-data-postgrest/blob/master/README.md#compound-primary-keys) or [`schema`](https://github.com/raphiniert-com/ra-data-postgrest/blob/master/README.md#custom-schema).
 
 ```jsx
 // in dataProvider.js
@@ -166,11 +166,13 @@ export const dataProvider = supabaseDataProvider({
     instanceUrl: 'YOUR_SUPABASE_URL',
     apiKey: 'YOUR_SUPABASE_ANON_KEY',
     supabaseClient,
-    primaryKeys: new Map([
-        ['some_table', ['custom_id']],
-        ['another_table', ['first_column', 'second_column']],
-    ]),
-    schema: () => localStorage.getItem('schema') || 'api',
+    postgrestOptions: {
+        primaryKeys: new Map([
+            ['some_table', ['custom_id']],
+            ['another_table', ['first_column', 'second_column']],
+        ]),
+        schema: () => localStorage.getItem('schema') || 'api',
+    },
 });
 ```
 

--- a/packages/ra-supabase/README.md
+++ b/packages/ra-supabase/README.md
@@ -155,7 +155,7 @@ As users authenticate through supabase, you can leverage [Row Level Security](ht
 
 #### Customizing the dataProvider
 
-`supabaseDataProvider` also accepts a `postgrestOptions` object to initialize the `ra-data-postgrest` dataProvider. This object accepts options like [`primaryKeys`](https://github.com/raphiniert-com/ra-data-postgrest/blob/master/README.md#compound-primary-keys) or [`schema`](https://github.com/raphiniert-com/ra-data-postgrest/blob/master/README.md#custom-schema).
+`supabaseDataProvider` also accepts the same options as the `ra-data-postgrest` dataProvider (except `apiUrl`), like [`primaryKeys`](https://github.com/raphiniert-com/ra-data-postgrest/blob/master/README.md#compound-primary-keys) or [`schema`](https://github.com/raphiniert-com/ra-data-postgrest/blob/master/README.md#custom-schema).
 
 ```jsx
 // in dataProvider.js
@@ -166,13 +166,11 @@ export const dataProvider = supabaseDataProvider({
     instanceUrl: 'YOUR_SUPABASE_URL',
     apiKey: 'YOUR_SUPABASE_ANON_KEY',
     supabaseClient,
-    postgrestOptions: {
-        primaryKeys: new Map([
-            ['some_table', ['custom_id']],
-            ['another_table', ['first_column', 'second_column']],
-        ]),
-        schema: () => localStorage.getItem('schema') || 'api',
-    },
+    primaryKeys: new Map([
+        ['some_table', ['custom_id']],
+        ['another_table', ['first_column', 'second_column']],
+    ]),
+    schema: () => localStorage.getItem('schema') || 'api',
 });
 ```
 


### PR DESCRIPTION
## Problem

PostGREST exposes a config option that ra-supabase doesn't expose: [sort order](https://github.com/raphiniert-com/ra-data-postgrest?tab=readme-ov-file#null-sort-order).

We could add a new parameter if it in the ra-supabase data provider constructor, but each time postgrest adds new configs, we'll need to update ra-supabase, too. 

## Solution

Add support for all possible postgrest config options, present and future, via a `rest` parameter
