### PR TITLE
Fix `authProvider.getPermissions()` should not throw error when not logged in

### DIFF
--- a/packages/ra-supabase-core/src/authProvider.ts
+++ b/packages/ra-supabase-core/src/authProvider.ts
@@ -173,10 +173,10 @@ export const supabaseAuthProvider = (
 
             const { data, error } = await client.auth.getUser();
             if (error) {
-                throw error;
+                return;
             }
             if (data.user == null) {
-                return undefined;
+                return;
             }
 
             if (typeof getPermissions === 'function') {


### PR DESCRIPTION
## Problem

The current setup disallows unauthenticated custom routes: the user is redirected to login.

## Solution

If no user is logged in, `getPermissions` should return `undefined` instead of redirecting to login.