### PR TITLE
Enable react-admin TS sourcemaps in production

### DIFF
--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -39,6 +39,41 @@ export default defineConfig({
     resolve: {
         preserveSymlinks: true,
         alias: [
+            {
+                find: 'ra-core',
+                replacement: path.resolve(
+                    __dirname,
+                    '../../node_modules/ra-core/src'
+                ),
+            },
+            {
+                find: 'ra-i18n-polyglot',
+                replacement: path.resolve(
+                    __dirname,
+                    '../../node_modules/ra-i18n-polyglot/src'
+                ),
+            },
+            {
+                find: 'ra-language-english',
+                replacement: path.resolve(
+                    __dirname,
+                    '../../node_modules/ra-language-english/src'
+                ),
+            },
+            {
+                find: 'ra-ui-materialui',
+                replacement: path.resolve(
+                    __dirname,
+                    '../../node_modules/ra-ui-materialui/src'
+                ),
+            },
+            {
+                find: 'react-admin',
+                replacement: path.resolve(
+                    __dirname,
+                    '../../node_modules/react-admin/src'
+                ),
+            },
             // we need to manually follow the symlinks for local packages to allow deep HMR
             ...Object.keys(aliases).map(packageName => ({
                 find: packageName,


### PR DESCRIPTION
## Problem

Debugging in production is hard with transpiled sources

## Solution

Enable TS sourcemap in production as explained at https://marmelab.com/react-admin/Vite.html#sourcemaps-in-production

## How To Test

- `make build-demo`
- `make run-prod`
- check that all react-admin related packages load their files from their `src` directory