### PR TITLE
Improve Reference inputs guessers

### DIFF
--- a/cypress/e2e/lists.cy.ts
+++ b/cypress/e2e/lists.cy.ts
@@ -7,14 +7,12 @@ describe('Lists', () => {
     it('should render a list', () => {
         cy.visit('/');
         login();
-        cy.findByText('Contacts').click();
         getPaginationText();
     });
 
     it('should allow to move through pages', () => {
         cy.visit('/');
         login();
-        cy.findByText('Contacts').click();
         getPaginationText().then(el => {
             const page = parseInt(el.text().split('-')[0].trim());
             cy.findByLabelText('Go to page 4').click();
@@ -40,7 +38,6 @@ describe('Lists', () => {
     it('should allow to sort data', () => {
         cy.visit('/');
         login();
-        cy.findByText('Contacts').click();
         cy.findByLabelText('Sort by gender ascending').click();
         cy.findAllByText('female', { timeout: 10000 }).should(
             'have.length',

--- a/packages/demo/src/dataGenerator/contacts.ts
+++ b/packages/demo/src/dataGenerator/contacts.ts
@@ -74,7 +74,7 @@ export const generateContacts = (
             last_seen: last_seen,
             has_newsletter: weightedBoolean(30),
             status: random.arrayElement(status),
-            tags: random
+            tag_ids: random
                 .arrayElements(db.tags, random.arrayElement([0, 0, 0, 1, 1, 2]))
                 .map(tag => tag.id), // finalize
             sales_id: company.sales_id,

--- a/packages/demo/src/types.ts
+++ b/packages/demo/src/types.ts
@@ -34,7 +34,7 @@ export interface Contact extends RaRecord {
     first_seen: string;
     last_seen: string;
     has_newsletter: Boolean;
-    tags: Identifier[];
+    tag_ids: Identifier[];
     gender: string;
     sales_id: Identifier;
     status: string;

--- a/packages/ra-supabase-ui-materialui/src/guessers/CreateGuesser.tsx
+++ b/packages/ra-supabase-ui-materialui/src/guessers/CreateGuesser.tsx
@@ -2,12 +2,13 @@ import * as React from 'react';
 import type { ReactNode } from 'react';
 import { useAPISchema } from 'ra-supabase-core';
 import { CreateBase, useResourceContext } from 'ra-core';
-import { CreateView, editFieldTypes, Loading } from 'react-admin';
+import { CreateView, Loading } from 'react-admin';
 import type { CreateProps, CreateViewProps } from 'ra-ui-materialui';
 import { capitalize, singularize } from 'inflection';
 
 import { inferElementFromType } from './inferElementFromType';
 import { InferredElement } from './InferredElement';
+import { editFieldTypes } from './editFieldTypes';
 
 export const CreateGuesser = (props: CreateProps & { enableLog?: boolean }) => {
     const {

--- a/packages/ra-supabase-ui-materialui/src/guessers/CreateGuesser.tsx
+++ b/packages/ra-supabase-ui-materialui/src/guessers/CreateGuesser.tsx
@@ -2,16 +2,12 @@ import * as React from 'react';
 import type { ReactNode } from 'react';
 import { useAPISchema } from 'ra-supabase-core';
 import { CreateBase, useResourceContext } from 'ra-core';
-import {
-    CreateView,
-    editFieldTypes,
-    InferredElement,
-    Loading,
-} from 'react-admin';
+import { CreateView, editFieldTypes, Loading } from 'react-admin';
 import type { CreateProps, CreateViewProps } from 'ra-ui-materialui';
 import { capitalize, singularize } from 'inflection';
 
 import { inferElementFromType } from './inferElementFromType';
+import { InferredElement } from './InferredElement';
 
 export const CreateGuesser = (props: CreateProps & { enableLog?: boolean }) => {
     const {
@@ -107,6 +103,10 @@ export const CreateGuesserView = (
             )
             .sort();
 
+        const warnings = inferredInputs
+            .map(inferredInput => inferredInput.getWarning())
+            .filter(warning => warning != null);
+
         // eslint-disable-next-line no-console
         console.log(
             `Guessed Create:
@@ -117,7 +117,11 @@ export const ${capitalize(singularize(resource))}Create = () => (
     <Create>
 ${representation}
     </Create>
-);`
+);${
+                warnings.length > 0
+                    ? warnings.map(warning => `\n\n${warning}`).join('')
+                    : ''
+            }`
         );
     }, [resource, isPending, error, schema, enableLog]);
 

--- a/packages/ra-supabase-ui-materialui/src/guessers/CreateGuesser.tsx
+++ b/packages/ra-supabase-ui-materialui/src/guessers/CreateGuesser.tsx
@@ -82,6 +82,7 @@ export const CreateGuesserView = (
                         ? resourceDefinition.properties![source].type
                         : 'string') as string,
                     requiredFields,
+                    schema,
                 })
             );
         const inferredForm = new InferredElement(

--- a/packages/ra-supabase-ui-materialui/src/guessers/EditGuesser.tsx
+++ b/packages/ra-supabase-ui-materialui/src/guessers/EditGuesser.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from 'react';
 import { useAPISchema } from 'ra-supabase-core';
 import { EditBase, InferredElement, useResourceContext } from 'ra-core';
 import {
-    editFieldTypes,
     type EditProps,
     EditView,
     type EditViewProps,
@@ -12,6 +11,7 @@ import {
 import { capitalize, singularize } from 'inflection';
 
 import { inferElementFromType } from './inferElementFromType';
+import { editFieldTypes } from './editFieldTypes';
 
 export const EditGuesser = (props: EditProps & { enableLogs?: boolean }) => {
     const {
@@ -86,6 +86,7 @@ export const EditGuesserView = (
                         ? resourceDefinition.properties![source].type
                         : 'string') as string,
                     requiredFields,
+                    schema,
                 })
             );
         const inferredForm = new InferredElement(

--- a/packages/ra-supabase-ui-materialui/src/guessers/EditGuesser.tsx
+++ b/packages/ra-supabase-ui-materialui/src/guessers/EditGuesser.tsx
@@ -111,6 +111,10 @@ export const EditGuesserView = (
             )
             .sort();
 
+        const warnings = inferredInputs
+            .map(inferredInput => inferredInput.getWarning())
+            .filter(warning => warning != null);
+
         // eslint-disable-next-line no-console
         console.log(
             `Guessed Edit:
@@ -121,7 +125,11 @@ export const ${capitalize(singularize(resource))}Edit = () => (
     <Edit>
 ${representation}
     </Edit>
-);`
+);${
+                warnings.length > 0
+                    ? warnings.map(warning => `\n\n${warning}`).join('')
+                    : ''
+            }`
         );
     }, [resource, isPending, error, schema, enableLog]);
 

--- a/packages/ra-supabase-ui-materialui/src/guessers/InferredElement.ts
+++ b/packages/ra-supabase-ui-materialui/src/guessers/InferredElement.ts
@@ -1,0 +1,16 @@
+import { InferredElement as CoreInferredElement, InferredType } from 'ra-core';
+
+export class InferredElement extends CoreInferredElement {
+    constructor(
+        type?: InferredType,
+        props?: any,
+        children?: any,
+        private warning?: string
+    ) {
+        super(type, props, children);
+    }
+
+    getWarning() {
+        return this.warning;
+    }
+}

--- a/packages/ra-supabase-ui-materialui/src/guessers/ListGuesser.tsx
+++ b/packages/ra-supabase-ui-materialui/src/guessers/ListGuesser.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from 'react';
 import { useAPISchema } from 'ra-supabase-core';
 import { InferredElement, ListBase, useResourceContext } from 'ra-core';
 import {
-    editFieldTypes,
     listFieldTypes,
     type ListProps,
     ListView,
@@ -14,6 +13,7 @@ import {
 import { capitalize, singularize } from 'inflection';
 
 import { inferElementFromType } from './inferElementFromType';
+import { editFieldTypes } from './editFieldTypes';
 
 export const ListGuesser = (props: ListProps & { enableLog?: boolean }) => {
     const {
@@ -94,6 +94,7 @@ export const ListGuesserView = (
                         'string'
                         ? resourceDefinition.properties![source].type
                         : 'string') as string,
+                    schema,
                 })
             );
         const inferredTable = new InferredElement(
@@ -122,6 +123,7 @@ export const ListGuesserView = (
                     description: field.description,
                     format: field.format,
                     type: field.type as string,
+                    schema,
                 });
             });
         if (
@@ -154,6 +156,7 @@ export const ListGuesserView = (
                             value ? value.substring(0, value.length - 2) : '',
                     },
                     type: field.type as string,
+                    schema,
                 })
             );
         }

--- a/packages/ra-supabase-ui-materialui/src/guessers/ListGuesser.tsx
+++ b/packages/ra-supabase-ui-materialui/src/guessers/ListGuesser.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { ReactNode } from 'react';
 import { useAPISchema } from 'ra-supabase-core';
-import { InferredElement, ListBase, useResourceContext } from 'ra-core';
+import { ListBase, useResourceContext } from 'ra-core';
 import {
     listFieldTypes,
     type ListProps,
@@ -13,6 +13,7 @@ import {
 import { capitalize, singularize } from 'inflection';
 
 import { inferElementFromType } from './inferElementFromType';
+import { InferredElement } from './InferredElement';
 import { editFieldTypes } from './editFieldTypes';
 
 export const ListGuesser = (props: ListProps & { enableLog?: boolean }) => {
@@ -195,6 +196,11 @@ ${inferredInputsForFilters
             new Set(['List', ...fieldComponents, ...filterComponents])
         ).sort();
 
+        const warnings = inferredInputsForFilters
+            .map(inferredInput => inferredInput.getWarning())
+            .concat(inferredFields.map(field => field.getWarning()))
+            .filter(warning => warning != null);
+
         // eslint-disable-next-line no-console
         console.log(
             `Guessed List:
@@ -206,7 +212,11 @@ export const ${capitalize(singularize(resource))}List = () => (
     <List${filterRepresentation ? ' filters={filters}' : ''}>
 ${tableRepresentation}
     </List>
-);`
+);${
+                warnings.length > 0
+                    ? warnings.map(warning => `\n\n${warning}`).join('')
+                    : ''
+            }`
         );
     }, [resource, isPending, error, schema, enableLog]);
 

--- a/packages/ra-supabase-ui-materialui/src/guessers/ShowGuesser.tsx
+++ b/packages/ra-supabase-ui-materialui/src/guessers/ShowGuesser.tsx
@@ -70,6 +70,7 @@ export const ShowGuesserView = (
                         'string'
                         ? resourceDefinition.properties![source].type
                         : 'string') as string,
+                    schema,
                 })
             );
         const inferredLayout = new InferredElement(

--- a/packages/ra-supabase-ui-materialui/src/guessers/ShowGuesser.tsx
+++ b/packages/ra-supabase-ui-materialui/src/guessers/ShowGuesser.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { ReactNode } from 'react';
 import { useAPISchema } from 'ra-supabase-core';
-import { InferredElement, ShowBase, useResourceContext } from 'ra-core';
+import { ShowBase, useResourceContext } from 'ra-core';
 import {
     Loading,
     showFieldTypes,
@@ -12,6 +12,7 @@ import {
 import { capitalize, singularize } from 'inflection';
 
 import { inferElementFromType } from './inferElementFromType';
+import { InferredElement } from './InferredElement';
 
 export const ShowGuesser = (props: ShowProps & { enableLog?: boolean }) => {
     const { id, disableAuthentication, queryOptions, resource, ...rest } =
@@ -95,6 +96,10 @@ export const ShowGuesserView = (
             )
             .sort();
 
+        const warnings = inferredFields
+            .map(inferredInput => inferredInput.getWarning())
+            .filter(warning => warning != null);
+
         // eslint-disable-next-line no-console
         console.log(
             `Guessed Show:
@@ -105,7 +110,11 @@ export const ${capitalize(singularize(resource))}Show = () => (
     <Show>
 ${representation}
     </Show>
-);`
+);${
+                warnings.length > 0
+                    ? warnings.map(warning => `\n\n${warning}`).join('')
+                    : ''
+            }`
         );
     }, [resource, isPending, error, schema, enableLog]);
 

--- a/packages/ra-supabase-ui-materialui/src/guessers/editFieldTypes.tsx
+++ b/packages/ra-supabase-ui-materialui/src/guessers/editFieldTypes.tsx
@@ -32,20 +32,25 @@ export const editFieldTypes: InferredTypeMap = {
                 : `<ReferenceInput source="${props.source}" reference="${props.reference}" />`,
     },
     autocompleteInput: {
-        component: (props: AutocompleteInputProps) => (
-            <AutocompleteInput
-                filterToQuery={searchText => ({
-                    [`${props.optionText}@ilike`]: `%${searchText}%`,
-                })}
-                {...props}
-            />
-        ),
+        component: (props: AutocompleteInputProps) =>
+            props.optionText ? (
+                <AutocompleteInput
+                    filterToQuery={searchText => ({
+                        [`${props.optionText}@ilike`]: `%${searchText}%`,
+                    })}
+                    {...props}
+                />
+            ) : (
+                <AutocompleteInput {...props} />
+            ),
         representation: (props: AutocompleteInputProps) =>
             `<AutocompleteInput${
                 props.source ? ` source="${props.source}"` : ''
-            } filterToQuery={searchText => ({ ${
+            }${
                 props.optionText
-            }@ilike: \`%\${searchText}%\` })} />`,
+                    ? ` filterToQuery={searchText => ({ ${props.optionText}@ilike: \`%\${searchText}%\` })}`
+                    : ''
+            } />`,
     },
     referenceArray: {
         component: ReferenceArrayInput,
@@ -62,19 +67,24 @@ export const editFieldTypes: InferredTypeMap = {
                 : `<ReferenceArrayInput source="${props.source}" reference="${props.reference}">\n\t\t<TextInput source="id" />\n\t</ReferenceArrayInput>`,
     },
     autocompleteArrayInput: {
-        component: (props: AutocompleteArrayInputProps) => (
-            <AutocompleteArrayInput
-                filterToQuery={searchText => ({
-                    [`${props.optionText}@ilike`]: `%${searchText}%`,
-                })}
-                {...props}
-            />
-        ),
+        component: (props: AutocompleteArrayInputProps) =>
+            props.optionText ? (
+                <AutocompleteArrayInput
+                    filterToQuery={searchText => ({
+                        [`${props.optionText}@ilike`]: `%${searchText}%`,
+                    })}
+                    {...props}
+                />
+            ) : (
+                <AutocompleteArrayInput {...props} />
+            ),
         representation: (props: AutocompleteInputProps) =>
             `<AutocompleteArrayInput${
                 props.source ? ` source="${props.source}"` : ''
-            } filterToQuery={searchText => ({ '${
+            }${
                 props.optionText
-            }@ilike': \`%\${searchText}%\` })} />`,
+                    ? ` filterToQuery={searchText => ({ ${props.optionText}@ilike: \`%\${searchText}%\` })}`
+                    : ''
+            } />`,
     },
 };

--- a/packages/ra-supabase-ui-materialui/src/guessers/editFieldTypes.tsx
+++ b/packages/ra-supabase-ui-materialui/src/guessers/editFieldTypes.tsx
@@ -64,7 +64,7 @@ export const editFieldTypes: InferredTypeMap = {
                   }">\n${children
                       .map(child => `\t\t${child.getRepresentation()}`)
                       .join('\n')}\n\t</ReferenceArrayInput>`
-                : `<ReferenceArrayInput source="${props.source}" reference="${props.reference}">\n\t\t<TextInput source="id" />\n\t</ReferenceArrayInput>`,
+                : `<ReferenceArrayInput source="${props.source}" reference="${props.reference}" />`,
     },
     autocompleteArrayInput: {
         component: (props: AutocompleteArrayInputProps) =>

--- a/packages/ra-supabase-ui-materialui/src/guessers/editFieldTypes.tsx
+++ b/packages/ra-supabase-ui-materialui/src/guessers/editFieldTypes.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { InferredElement, InferredTypeMap } from 'ra-core';
+import {
+    AutocompleteArrayInput,
+    AutocompleteArrayInputProps,
+    AutocompleteInput,
+    AutocompleteInputProps,
+    editFieldTypes as defaultEditFieldTypes,
+    ReferenceArrayInput,
+    ReferenceArrayInputProps,
+    ReferenceInput,
+    ReferenceInputProps,
+} from 'ra-ui-materialui';
+
+export const editFieldTypes: InferredTypeMap = {
+    ...defaultEditFieldTypes,
+    reference: {
+        component: ReferenceInput,
+        representation: (
+            props: ReferenceInputProps,
+            children?: InferredElement[]
+        ) =>
+            children
+                ? `<ReferenceInput source="${props.source}" reference="${
+                      props.reference
+                  }">\n${children
+                      .map(
+                          child =>
+                              `                ${child.getRepresentation()}`
+                      )
+                      .join('\n')}\n            </ReferenceInput>`
+                : `<ReferenceInput source="${props.source}" reference="${props.reference}" />`,
+    },
+    autocompleteInput: {
+        component: (props: AutocompleteInputProps) => (
+            <AutocompleteInput
+                filterToQuery={searchText => ({
+                    [`${props.optionText}@ilike`]: `%${searchText}%`,
+                })}
+                {...props}
+            />
+        ),
+        representation: (props: AutocompleteInputProps) =>
+            `<AutocompleteInput${
+                props.source ? ` source="${props.source}"` : ''
+            } filterToQuery={searchText => ({ ${
+                props.optionText
+            }@ilike: \`%\${searchText}%\` })} />`,
+    },
+    referenceArray: {
+        component: ReferenceArrayInput,
+        representation: (
+            props: ReferenceArrayInputProps,
+            children?: InferredElement[]
+        ) =>
+            children
+                ? `<ReferenceArrayInput source="${props.source}" reference="${
+                      props.reference
+                  }">\n${children
+                      .map(child => `\t\t${child.getRepresentation()}`)
+                      .join('\n')}\n\t</ReferenceArrayInput>`
+                : `<ReferenceArrayInput source="${props.source}" reference="${props.reference}">\n\t\t<TextInput source="id" />\n\t</ReferenceArrayInput>`,
+    },
+    autocompleteArrayInput: {
+        component: (props: AutocompleteArrayInputProps) => (
+            <AutocompleteArrayInput
+                filterToQuery={searchText => ({
+                    [`${props.optionText}@ilike`]: `%${searchText}%`,
+                })}
+                {...props}
+            />
+        ),
+        representation: (props: AutocompleteInputProps) =>
+            `<AutocompleteArrayInput${
+                props.source ? ` source="${props.source}"` : ''
+            } filterToQuery={searchText => ({ '${
+                props.optionText
+            }@ilike': \`%\${searchText}%\` })} />`,
+    },
+};

--- a/packages/ra-supabase-ui-materialui/src/guessers/inferElementFromType.ts
+++ b/packages/ra-supabase-ui-materialui/src/guessers/inferElementFromType.ts
@@ -52,15 +52,9 @@ export const inferElementFromType = ({
             hasType('autocompleteInput', types) &&
             referenceRecordRepresentationField
                 ? [
-                      new InferredElement(
-                          types.autocompleteInput,
-                          referenceRecordRepresentationField
-                              ? {
-                                    optionText:
-                                        referenceRecordRepresentationField,
-                                }
-                              : {}
-                      ),
+                      new InferredElement(types.autocompleteInput, {
+                          optionText: referenceRecordRepresentationField,
+                      }),
                   ]
                 : undefined,
             hasType('autocompleteInput', types) &&
@@ -71,7 +65,7 @@ export const inferElementFromType = ({
     }
     if (
         name.substring(name.length - 4) === '_ids' &&
-        hasType('reference', types)
+        hasType('referenceArray', types)
     ) {
         const reference = pluralize(name.substr(0, name.length - 4));
         const referenceResourceDefinition = schema.definitions?.[reference];
@@ -93,15 +87,9 @@ export const inferElementFromType = ({
             hasType('autocompleteArrayInput', types) &&
             referenceRecordRepresentationField
                 ? [
-                      new InferredElement(
-                          types.autocompleteArrayInput,
-                          referenceRecordRepresentationField
-                              ? {
-                                    optionText:
-                                        referenceRecordRepresentationField,
-                                }
-                              : {}
-                      ),
+                      new InferredElement(types.autocompleteArrayInput, {
+                          optionText: referenceRecordRepresentationField,
+                      }),
                   ]
                 : undefined,
             hasType('autocompleteArrayInput', types) &&

--- a/packages/ra-supabase-ui-materialui/src/guessers/inferElementFromType.ts
+++ b/packages/ra-supabase-ui-materialui/src/guessers/inferElementFromType.ts
@@ -1,6 +1,7 @@
-import { InferredElement, required, type InferredTypeMap } from 'ra-core';
+import { required, type InferredTypeMap } from 'ra-core';
 import { pluralize } from 'inflection';
 import type { OpenAPIV2 } from 'openapi-types';
+import { InferredElement } from './InferredElement';
 
 const hasType = (type, types) => typeof types[type] !== 'undefined';
 
@@ -48,16 +49,24 @@ export const inferElementFromType = ({
                 reference,
                 ...props,
             },
-            [
-                new InferredElement(
-                    types.autocompleteInput,
-                    referenceRecordRepresentationField
-                        ? {
-                              optionText: referenceRecordRepresentationField,
-                          }
-                        : {}
-                ),
-            ]
+            hasType('autocompleteInput', types) &&
+            referenceRecordRepresentationField
+                ? [
+                      new InferredElement(
+                          types.autocompleteInput,
+                          referenceRecordRepresentationField
+                              ? {
+                                    optionText:
+                                        referenceRecordRepresentationField,
+                                }
+                              : {}
+                      ),
+                  ]
+                : undefined,
+            hasType('autocompleteInput', types) &&
+            !referenceRecordRepresentationField
+                ? `Could not infer the field to use to filter referenced ${reference} records. Please provide the \`filterToQuery\` prop to the <AutocompleteInput> component. See https://github.com/marmelab/ra-supabase/blob/main/packages/ra-supabase/README.md#autocompleteinput-with-references`
+                : undefined
         );
     }
     if (
@@ -81,16 +90,24 @@ export const inferElementFromType = ({
                 reference,
                 ...props,
             },
-            [
-                new InferredElement(
-                    types.autocompleteArrayInput,
-                    referenceRecordRepresentationField
-                        ? {
-                              optionText: referenceRecordRepresentationField,
-                          }
-                        : {}
-                ),
-            ]
+            hasType('autocompleteArrayInput', types) &&
+            referenceRecordRepresentationField
+                ? [
+                      new InferredElement(
+                          types.autocompleteArrayInput,
+                          referenceRecordRepresentationField
+                              ? {
+                                    optionText:
+                                        referenceRecordRepresentationField,
+                                }
+                              : {}
+                      ),
+                  ]
+                : undefined,
+            hasType('autocompleteArrayInput', types) &&
+            !referenceRecordRepresentationField
+                ? `Could not infer the field to use to filter referenced ${reference} records. Please provide the \`filterToQuery\` prop to the <AutocompleteArrayInput> component. See https://github.com/marmelab/ra-supabase/blob/main/packages/ra-supabase/README.md#autocompleteinput-with-references`
+                : undefined
         );
     }
     if (type === 'array') {
@@ -165,8 +182,5 @@ const inferRecordRepresentationField = (
     }
     if (referenceResourceDefinition.properties?.reference != null) {
         return 'reference';
-    }
-    if (referenceResourceDefinition.properties?.email != null) {
-        return 'email';
     }
 };

--- a/packages/ra-supabase/README.md
+++ b/packages/ra-supabase/README.md
@@ -296,6 +296,40 @@ export const MyAdmin = () => (
 );
 ```
 
+## AutocompleteInput With References
+
+By default, React Admin `<AutocompleteInput>` component inside a `<ReferenceInput>` will query the dataProvider with a filter on the `q` field. This doesn't work with Supabase.
+You must set the `filterToQuery` prop so that it filters the references correctly. For instance, for a list of contacts having a company that has a `name` prop:
+
+```tsx
+import { AutocompleteInput, Datagrid, List, ReferenceField, ReferenceInput, TextField } from 'react-admin';
+
+const filters = [
+    <ReferenceInput source="company_id" reference="companies">
+        <AutocompleteInput filterToQuery={searchText => ({ 'name@ilike': `%${searchText}%` })} />
+    </ReferenceInput>
+];
+
+export const ContactList = () => (
+    <List filters={filters}>
+        <Datagrid>
+            <TextField source="id" />
+            <TextField source="first_name" />
+            <TextField source="last_name" />
+            <ReferenceField source="company_id" reference="companies" />
+        </Datagrid>
+    </List>
+);
+```
+
+The [guessers](#guessers) will try their best to infer commonly used fields for filtering. If the referenced resource contains any of these fields, it will be targeted for filtering:
+
+- `name`
+- `title`
+- `label`
+- `reference`
+- `email`
+
 ## Using Hash Router
 
 Supabase uses URL hash links for its redirections. This can cause conflicts if you use a HashRouter. For this reason, we recommend using the BrowserRouter.

--- a/packages/ra-supabase/README.md
+++ b/packages/ra-supabase/README.md
@@ -296,9 +296,10 @@ export const MyAdmin = () => (
 );
 ```
 
-## AutocompleteInput With References
+## References Inputs
 
-By default, React Admin `<AutocompleteInput>` component inside a `<ReferenceInput>` will query the dataProvider with a filter on the `q` field. This doesn't work with Supabase.
+By default, React Admin adds an `<AutocompleteInput>` component inside all `<ReferenceInput>` and it will query the dataProvider with a filter on the `q` field. This doesn't work with Supabase. This is also true for `<ReferenceArrayInput>` and its `<AutocompleteArrayInput>` child.
+
 You must set the `filterToQuery` prop so that it filters the references correctly. For instance, for a list of contacts having a company that has a `name` prop:
 
 ```tsx
@@ -328,7 +329,6 @@ The [guessers](#guessers) will try their best to infer commonly used fields for 
 - `title`
 - `label`
 - `reference`
-- `email`
 
 ## Using Hash Router
 

--- a/supabase/migrations/20250325160944_contact_tags.sql
+++ b/supabase/migrations/20250325160944_contact_tags.sql
@@ -1,0 +1,3 @@
+alter table "public"."contacts" rename column "tags" TO "tag_ids";
+
+


### PR DESCRIPTION
## Problem

Default reference inputs guessed for lists filters and edit views filters their references with the default `q` field which does not exist in Supabase. This results in an error.

## Solution

- [x] Try to infer the reference field to use for filtering like we do for record representation
- [x] Document how to set up the `<AutocompleteInput filterToQuery>` for other cases
- [x] Log a message for those cases with the guessers, including instructions to solve them

## How to test

- `make supabase-start run`
- Open the contact list and add a company fiilter.

Then:

- Check that it filters companies correctly
- Check that there is a message from the guessers explaning how to fix the sales reference input

Then:
- Open any contact in edition

Then:

- Check that it filters companies correctly
- Check that there is a message from the guessers explaning how to fix the sales reference input