### PR TITLE
Fix generated representation for `<AutocompleteInput>` and `<AutocompleteArrayInput>`

### DIFF
--- a/packages/ra-supabase-ui-materialui/src/guessers/editFieldTypes.tsx
+++ b/packages/ra-supabase-ui-materialui/src/guessers/editFieldTypes.tsx
@@ -48,7 +48,7 @@ export const editFieldTypes: InferredTypeMap = {
                 props.source ? ` source="${props.source}"` : ''
             }${
                 props.optionText
-                    ? ` filterToQuery={searchText => ({ ${props.optionText}@ilike: \`%\${searchText}%\` })}`
+                    ? ` filterToQuery={searchText => ({ '${props.optionText}@ilike': \`%\${searchText}%\` })}`
                     : ''
             } />`,
     },
@@ -83,7 +83,7 @@ export const editFieldTypes: InferredTypeMap = {
                 props.source ? ` source="${props.source}"` : ''
             }${
                 props.optionText
-                    ? ` filterToQuery={searchText => ({ ${props.optionText}@ilike: \`%\${searchText}%\` })}`
+                    ? ` filterToQuery={searchText => ({ '${props.optionText}@ilike': \`%\${searchText}%\` })}`
                     : ''
             } />`,
     },


### PR DESCRIPTION
### Problem

The generated code representation (in the DevTools) appears like:

```tsx
        <AutocompleteInput
            filterToQuery={searchText => ({ name@ilike: `%${searchText}%` })}
        />
```

Which is invalid code.

It should instead be:

```tsx
        <AutocompleteInput
            filterToQuery={searchText => ({ 'name@ilike': `%${searchText}%` })}
        />
```

(`'name@ilike'` instead of `name@ilike`)