### PR TITLE
Improve authentication related pages UX by showing the loading state

### DIFF
--- a/packages/ra-supabase-ui-materialui/src/ForgotPasswordForm.tsx
+++ b/packages/ra-supabase-ui-materialui/src/ForgotPasswordForm.tsx
@@ -10,7 +10,7 @@ import { Link, SaveButton, TextInput } from 'ra-ui-materialui';
 export const ForgotPasswordForm = () => {
     const notify = useNotify();
     const translate = useTranslate();
-    const [resetPassword] = useResetPassword({
+    const [, { mutateAsync: resetPassword }] = useResetPassword({
         onError: error => {
             notify(
                 typeof error === 'string'
@@ -33,10 +33,14 @@ export const ForgotPasswordForm = () => {
         },
     });
 
-    const submit = (values: FormData) => {
-        return resetPassword({
-            email: values.email,
-        });
+    const submit = async (values: FormData) => {
+        try {
+            await resetPassword({
+                email: values.email,
+            });
+        } catch (error) {
+            notify(error?.message ?? 'ra.notification.http_error');
+        }
     };
 
     return (

--- a/packages/ra-supabase-ui-materialui/src/ForgotPasswordForm.tsx
+++ b/packages/ra-supabase-ui-materialui/src/ForgotPasswordForm.tsx
@@ -10,8 +10,14 @@ import { Link, SaveButton, TextInput } from 'ra-ui-materialui';
 export const ForgotPasswordForm = () => {
     const notify = useNotify();
     const translate = useTranslate();
-    const [, { mutateAsync: resetPassword }] = useResetPassword({
-        onError: error => {
+    const [, { mutateAsync: resetPassword }] = useResetPassword();
+
+    const submit = async (values: FormData) => {
+        try {
+            await resetPassword({
+                email: values.email,
+            });
+        } catch (error) {
             notify(
                 typeof error === 'string'
                     ? error
@@ -30,16 +36,6 @@ export const ForgotPasswordForm = () => {
                     },
                 }
             );
-        },
-    });
-
-    const submit = async (values: FormData) => {
-        try {
-            await resetPassword({
-                email: values.email,
-            });
-        } catch (error) {
-            notify(error?.message ?? 'ra.notification.http_error');
         }
     };
 

--- a/packages/ra-supabase-ui-materialui/src/SetPasswordForm.tsx
+++ b/packages/ra-supabase-ui-materialui/src/SetPasswordForm.tsx
@@ -16,28 +16,7 @@ export const SetPasswordForm = () => {
 
     const notify = useNotify();
     const translate = useTranslate();
-    const [, { mutateAsync: setPassword }] = useSetPassword({
-        onError: error => {
-            notify(
-                typeof error === 'string'
-                    ? error
-                    : typeof error === 'undefined' || !error.message
-                    ? 'ra.auth.sign_in_error'
-                    : error.message,
-                {
-                    type: 'warning',
-                    messageArgs: {
-                        _:
-                            typeof error === 'string'
-                                ? error
-                                : error && error.message
-                                ? error.message
-                                : undefined,
-                    },
-                }
-            );
-        },
-    });
+    const [, { mutateAsync: setPassword }] = useSetPassword();
 
     const validate = (values: FormData) => {
         if (values.password !== values.confirmPassword) {
@@ -70,7 +49,24 @@ export const SetPasswordForm = () => {
                 password: values.password,
             });
         } catch (error) {
-            notify(error?.message ?? 'ra.notification.http_error');
+            notify(
+                typeof error === 'string'
+                    ? error
+                    : typeof error === 'undefined' || !error.message
+                    ? 'ra.auth.sign_in_error'
+                    : error.message,
+                {
+                    type: 'warning',
+                    messageArgs: {
+                        _:
+                            typeof error === 'string'
+                                ? error
+                                : error && error.message
+                                ? error.message
+                                : undefined,
+                    },
+                }
+            );
         }
     };
 

--- a/packages/ra-supabase-ui-materialui/src/SetPasswordForm.tsx
+++ b/packages/ra-supabase-ui-materialui/src/SetPasswordForm.tsx
@@ -16,7 +16,7 @@ export const SetPasswordForm = () => {
 
     const notify = useNotify();
     const translate = useTranslate();
-    const [setPassword] = useSetPassword({
+    const [, { mutateAsync: setPassword }] = useSetPassword({
         onError: error => {
             notify(
                 typeof error === 'string'
@@ -62,12 +62,16 @@ export const SetPasswordForm = () => {
         );
     }
 
-    const submit = (values: FormData) => {
-        return setPassword({
-            access_token,
-            refresh_token,
-            password: values.password,
-        });
+    const submit = async (values: FormData) => {
+        try {
+            await setPassword({
+                access_token,
+                refresh_token,
+                password: values.password,
+            });
+        } catch (error) {
+            notify(error?.message ?? 'ra.notification.http_error');
+        }
     };
 
     return (


### PR DESCRIPTION
## Problem

> The auth callbacks (reset password, etc.) can take non-negligible amounts of time. There is currently no visual feedback - meaning users might think that the button press weren't successfully registered, potentially causing them to press several times.

Fixes #87

## Solution

Use the `mutateAsync` method of react-query mutations in the form submit so that react-hook-form `isSubmitting` state is tied to it.

## How to test

Difficult to test with the current demo.
- Open `./packages/ra-supabase-core/src/authProvider.ts`
- add a `await new Promise(resolve => settimeout(resolve, 2000))` to `login`, `setPassword` and `resetPassword` methods
- run the application
- click *forgot password* and fill the form (`janedoe@atomic.dev`) then submit: you should see the loading state
- open inbucket (http://localhost:54324/m/janedoe) and click the link in the forgot email
- fill the form then submit: you should see the loading state
- log out and fill the login form then submit: you should see the loading state
