### PR TITLE
Fix(ra-supabase-core): Remove dependency to react-admin in ra-supabase-core

### DIFF
--- a/packages/ra-supabase-core/src/useAPISchema.ts
+++ b/packages/ra-supabase-core/src/useAPISchema.ts
@@ -1,7 +1,7 @@
-import { useDataProvider } from 'react-admin';
-import { useQuery } from '@tanstack/react-query';
 import type { UseQueryOptions } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import type { OpenAPIV2 } from 'openapi-types';
+import { useDataProvider } from 'ra-core';
 
 export const useAPISchema = ({
     options,


### PR DESCRIPTION
# Problem

`ra-supabase-core` does not have a dependnecy to react-admin, but `useAPISchema` depends on `react-admin`

# Solution
Replace dependency from `react-admin` to `ra-core`