### PR TITLE
Update filter input for title in README

### DIFF
--- a/packages/ra-supabase/README.md
+++ b/packages/ra-supabase/README.md
@@ -146,7 +146,7 @@ When specifying the `source` prop of filter inputs, you can either set it to the
 
 ```jsx
 const postFilters = [
-  <SearchInput source="title@ilike" alwaysOn />,
+    <SearchInput source="title@ilike" alwaysOn />,
     <TextInput label="Views" source="views@gte" />,
 ];
 

--- a/packages/ra-supabase/README.md
+++ b/packages/ra-supabase/README.md
@@ -146,7 +146,7 @@ When specifying the `source` prop of filter inputs, you can either set it to the
 
 ```jsx
 const postFilters = [
-    <TextInput label="Title" source="title@ilike" alwaysOn />,
+  <SearchInput source="title@ilike" alwaysOn />,
     <TextInput label="Views" source="views@gte" />,
 ];
 


### PR DESCRIPTION
Replaced TextInput with SearchInput for title filter. Textinput does not show the searchbutton especailly for shadcn datatable