### PR TITLE
Add support publishable key

### DIFF
--- a/packages/ra-supabase-core/README.md
+++ b/packages/ra-supabase-core/README.md
@@ -16,7 +16,7 @@ npm install ra-supabase-core
 // in supabase.js
 import { createClient } from '@supabase/supabase-js';
 
-export const supabase = createClient('YOUR_SUPABASE_URL', 'YOUR_SUPABASE_ANON_KEY');
+export const supabase = createClient('YOUR_SUPABASE_URL', 'YOUR_SUPABASE_ANON_KEY_OR_PUBLISHABLE_KEY');
 
 // in dataProvider.js
 import { supabaseDataProvider } from 'ra-supabase-core';
@@ -24,7 +24,7 @@ import { supabase } from './supabase';
 
 export const dataProvider = supabaseDataProvider({
     instanceUrl: 'YOUR_SUPABASE_URL',
-    apiKey: 'YOUR_SUPABASE_ANON_KEY',
+    apiKey: 'YOUR_SUPABASE_ANON_KEY_OR_PUBLISHABLE_KEY',
     supabase
 });
 
@@ -91,7 +91,7 @@ See the [PostgREST documentation](https://postgrest.org/en/stable/api.html#opera
 
 #### RLS
 
-As users authenticate through supabase, you can leverage [Row Level Security](https://supabase.com/docs/guides/auth/row-level-security). Users identity will be propagated through the dataProvider if you provided the public API (anon) key. Keep in mind that passing the `service_role` key will bypass Row Level Security. This is not recommended.
+As users authenticate through supabase, you can leverage [Row Level Security](https://supabase.com/docs/guides/auth/row-level-security). Users identity will be propagated through the dataProvider if you provided the public API (anon) key or a publishable key (`sb_publishable_*`). Keep in mind that passing the `service_role` key will bypass Row Level Security. This is not recommended.
 
 #### Customizing the dataProvider
 
@@ -104,7 +104,7 @@ import { supabaseClient } from './supabase';
 
 export const dataProvider = supabaseDataProvider({
     instanceUrl: 'YOUR_SUPABASE_URL',
-    apiKey: 'YOUR_SUPABASE_ANON_KEY',
+    apiKey: 'YOUR_SUPABASE_ANON_KEY_OR_PUBLISHABLE_KEY',
     supabaseClient,
     primaryKeys: new Map([
         ['some_table', ['custom_id']],

--- a/packages/ra-supabase-core/src/dataProvider.ts
+++ b/packages/ra-supabase-core/src/dataProvider.ts
@@ -8,11 +8,33 @@ import { createClient } from '@supabase/supabase-js';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { OpenAPIV2 } from 'openapi-types';
 
+type WithApiKey = {
+    instanceUrl: string;
+    /**
+     * The API key of the Supabase instance. Accepts both the legacy anonymous
+     * JWT key and the newer publishable key (`sb_publishable_*`).
+     * Either `apiKey` or `supabaseClient` must be provided.
+     */
+    apiKey: string;
+    supabaseClient?: SupabaseClient;
+};
+
+type WithSupabaseClient = {
+    instanceUrl: string;
+    /**
+     * A pre-configured Supabase client. Required when `apiKey` is not provided.
+     * Use this when you create the client with a publishable key and want to
+     * pass it directly without also specifying the key separately.
+     */
+    supabaseClient: SupabaseClient;
+    apiKey?: never;
+};
+
 /**
  * A function that returns a dataProvider for Supabase.
  * @param instanceUrl The URL of the Supabase instance
- * @param apiKey The API key of the Supabase instance. Prefer the anonymous key.
- * @param supabaseClient The Supabase client
+ * @param apiKey The API key of the Supabase instance. Accepts the legacy anonymous JWT key or the newer publishable key (`sb_publishable_*`). Either `apiKey` or `supabaseClient` must be provided.
+ * @param supabaseClient The Supabase client. Required when `apiKey` is not provided.
  * @param httpClient Optional - The httpClient to use. Defaults to a httpClient that handles the authentication.
  * @param defaultListOp Optional - The default list filter operator. Defaults to 'eq'.
  * @param primaryKeys Optional - The primary keys of the tables. Defaults to 'id'.
@@ -22,17 +44,27 @@ import type { OpenAPIV2 } from 'openapi-types';
 export const supabaseDataProvider = ({
     instanceUrl,
     apiKey,
-    supabaseClient = createClient(instanceUrl, apiKey),
-    httpClient = supabaseHttpClient({ apiKey, supabaseClient }),
+    supabaseClient: supabaseClientParam,
+    httpClient: httpClientParam,
     defaultListOp = 'eq',
     primaryKeys = defaultPrimaryKeys,
     schema = defaultSchema,
     ...rest
-}: {
-    instanceUrl: string;
-    apiKey: string;
-    supabaseClient?: SupabaseClient;
-} & Partial<Omit<IDataProviderConfig, 'apiUrl'>>): DataProvider => {
+}: (WithApiKey | WithSupabaseClient) &
+    Partial<Omit<IDataProviderConfig, 'apiUrl'>>): DataProvider => {
+    const supabaseClient =
+        supabaseClientParam ??
+        (apiKey
+            ? createClient(instanceUrl, apiKey)
+            : (() => {
+                  throw new Error(
+                      'Either apiKey or supabaseClient must be provided to supabaseDataProvider'
+                  );
+              })());
+    const httpClient =
+        httpClientParam ??
+        supabaseHttpClient({ apiKey, supabaseClient });
+
     const config: IDataProviderConfig = {
         apiUrl: `${instanceUrl}/rest/v1`,
         httpClient,
@@ -57,7 +89,7 @@ export const supabaseDataProvider = ({
 
 /**
  * A function that returns a httpClient for Supabase. It handles the authentication.
- * @param apiKey The API key of the Supabase instance. Prefer the anonymous key.
+ * @param apiKey The API key of the Supabase instance. Accepts the legacy anonymous JWT key or the newer publishable key (`sb_publishable_*`). When omitted, the key configured on the `supabaseClient` is used via its internal headers.
  * @param supabaseClient The Supabase client
  * @returns A httpClient for Supabase
  */
@@ -66,7 +98,7 @@ export const supabaseHttpClient =
         apiKey,
         supabaseClient,
     }: {
-        apiKey: string;
+        apiKey?: string;
         supabaseClient: SupabaseClient;
     }) =>
     async (url: string, options: any = {}) => {
@@ -85,8 +117,14 @@ export const supabaseHttpClient =
                 token: `Bearer ${data.session.access_token}`,
             };
         }
-        // Always send the apiKey even if there isn't a session
-        options.headers.set('apiKey', apiKey);
+        // When apiKey is explicitly provided, set it in the header to ensure it
+        // takes precedence over the supabaseClient internal headers. When omitted,
+        // the key from supabaseClient['headers'] (set by the copy loop above) is
+        // used instead — this supports the publishable key format (`sb_publishable_*`)
+        // where the supabase-js client manages the key internally.
+        if (apiKey !== undefined) {
+            options.headers.set('apiKey', apiKey);
+        }
 
         return fetchUtils.fetchJson(url, options);
     };

--- a/packages/ra-supabase-ui-materialui/README.md
+++ b/packages/ra-supabase-ui-materialui/README.md
@@ -16,7 +16,7 @@ npm install ra-supabase-ui-materialui
 // in supabase.js
 import { createClient } from '@supabase/supabase-js';
 
-export const supabase = createClient('YOUR_SUPABASE_URL', 'YOUR_SUPABASE_ANON_KEY');
+export const supabase = createClient('YOUR_SUPABASE_URL', 'YOUR_SUPABASE_ANON_KEY_OR_PUBLISHABLE_KEY');
 
 // in dataProvider.js
 import { supabaseDataProvider } from 'ra-supabase-core';
@@ -24,7 +24,7 @@ import { supabaseClient } from './supabase';
 
 export const dataProvider = supabaseDataProvider({
     instanceUrl: 'YOUR_SUPABASE_URL',
-    apiKey: 'YOUR_SUPABASE_ANON_KEY',
+    apiKey: 'YOUR_SUPABASE_ANON_KEY_OR_PUBLISHABLE_KEY',
     supabaseClient
 });
 

--- a/packages/ra-supabase/README.md
+++ b/packages/ra-supabase/README.md
@@ -16,7 +16,7 @@ Edit `.env` and populate it with your Supabase connection variables:
 
 ```env
 VITE_SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
-VITE_SUPABASE_API_KEY=<SUBSTITUTE_SUPABASE_ANON_KEY>
+VITE_SUPABASE_API_KEY=<SUBSTITUTE_SUPABASE_ANON_KEY_OR_PUBLISHABLE_KEY>
 ```
 
 Make the data in your database readable by authenticated users by adding an RLS policy:
@@ -271,7 +271,7 @@ const dataProvider = supabaseDataProvider(config);
 
 ### Row-Level Security
 
-As users authenticate through supabase, you can leverage [Row Level Security](https://supabase.com/docs/guides/auth/row-level-security). Users identity will be propagated through the dataProvider if you provided the public API (anon) key. Keep in mind that passing the `service_role` key will bypass Row Level Security. This is not recommended.
+As users authenticate through supabase, you can leverage [Row Level Security](https://supabase.com/docs/guides/auth/row-level-security). Users identity will be propagated through the dataProvider if you provided the public API (anon) key or a publishable key (`sb_publishable_*`). Keep in mind that passing the `service_role` key will bypass Row Level Security. This is not recommended.
 
 ## Guessers
 
@@ -380,7 +380,7 @@ import { supabaseClient } from './supabase';
 
 export const dataProvider = supabaseDataProvider({
     instanceUrl: 'YOUR_SUPABASE_URL',
-    apiKey: 'YOUR_SUPABASE_ANON_KEY',
+    apiKey: 'YOUR_SUPABASE_ANON_KEY_OR_PUBLISHABLE_KEY',
     supabaseClient,
     primaryKeys: new Map([
         ['some_table', ['custom_id']],

--- a/packages/ra-supabase/src/AdminGuesser.tsx
+++ b/packages/ra-supabase/src/AdminGuesser.tsx
@@ -20,7 +20,14 @@ import { createClient } from '@supabase/supabase-js';
 import { defaultI18nProvider } from './defaultI18nProvider';
 
 export const AdminGuesser = (
-    props: AdminProps & { instanceUrl: string; apiKey: string }
+    props: AdminProps & {
+        instanceUrl: string;
+        /**
+         * The API key of the Supabase instance. Accepts both the legacy anonymous
+         * JWT key and the newer publishable key (`sb_publishable_*`).
+         */
+        apiKey: string;
+    }
 ) => {
     const {
         instanceUrl,


### PR DESCRIPTION
Hi.

New use of "ANON key" is deprecated in favor of "Publishable key".

ref. https://github.com/orgs/supabase/discussions/29260

This PR adds support for "Publishable key".


